### PR TITLE
[MergeRq] Add Makefile functions [Tested]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.exe
 *.dll
 *.so
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+# Directorios
+SRC_DIR = src
+INC_DIR = include
+BIN_DIR = bin
+
+# Archivos fuente y objeto
+SRC = $(SRC_DIR)/main.c $(SRC_DIR)/dynamicarray.c
+OBJ = $(SRC:.c=.o)
+
+# Compilador y flags
+CC = gcc
+CFLAGS = -I$(INC_DIR) -Wall -Wextra -g
+
+# Ejecutable
+EXEC = $(BIN_DIR)/main
+
+# Regla por defecto
+all: $(BIN_DIR) $(EXEC)
+
+# Compilación del ejecutable
+$(EXEC): $(OBJ)
+	$(CC) $(OBJ) -o $@
+
+# Crear directorio bin si no existe
+$(BIN_DIR):
+	mkdir -p $(BIN_DIR)
+
+# Limpiar archivos generados
+clean:
+	rm -f $(SRC_DIR)/*.o
+	rm -f $(EXEC)


### PR DESCRIPTION
[AUTO GENERATED]

This pull request introduces a new `Makefile` to streamline the build process for the project. The `Makefile` defines directories, source files, compiler settings, and build rules, making it easier to compile and manage the project.

Build process setup:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R31): Added definitions for source (`SRC_DIR`), include (`INC_DIR`), and binary (`BIN_DIR`) directories to organize project files.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R31): Configured source files (`SRC`) and object files (`OBJ`) to automate compilation and linking.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R31): Specified the compiler (`gcc`) and flags (`CFLAGS`) to ensure consistent build settings across environments.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R31): Implemented rules for building the executable (`EXEC`), creating the binary directory if it doesn't exist, and cleaning up generated files.